### PR TITLE
Semicolons (codestyle)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "esversion": 6,
   "curly": true,
   "eqeqeq": true,
   "newcap": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
-  "esversion": 6,
+  "esnext": true,
   "curly": true,
   "eqeqeq": true,
   "newcap": true,

--- a/hash-sum.js
+++ b/hash-sum.js
@@ -43,16 +43,16 @@ function foldValue (input, value, key, seen) {
     }
     seen.push(value);
 
-    var objHash = foldObject(hash, value, seen)
+    var objHash = foldObject(hash, value, seen);
 
     if (!('valueOf' in value) || typeof value.valueOf !== 'function') {
       return objHash;
     }
 
     try {
-      return fold(objHash, String(value.valueOf()))
+      return fold(objHash, String(value.valueOf()));
     } catch (err) {
-      return fold(objHash, '[valueOf exception]' + (err.stack || err.message))
+      return fold(objHash, '[valueOf exception]' + (err.stack || err.message));
     }
   }
   return fold(hash, value.toString());

--- a/test.js
+++ b/test.js
@@ -51,11 +51,11 @@ test('creates unique hashes', function (t) {
   test_case(new Date(1988, 5, 9));
   test_case(global, 'global');
 
-  const uniqCases = _.uniqBy(cases, 'hash')
+  const uniqCases = _.uniqBy(cases, 'hash');
   _.uniqBy(cases, 'hash').forEach(function (expected) {
-    var matches = _.filter(cases, { hash: expected.hash })
-    t.equal(matches.length, 1, expected.hash + ': ' + _.map(matches, 'value').join(' '))
-  })
+    var matches = _.filter(cases, { hash: expected.hash });
+    t.equal(matches.length, 1, expected.hash + ': ' + _.map(matches, 'value').join(' '));
+  });
 
   t.end();
 
@@ -71,7 +71,7 @@ test('hashes clash if same properties', function (t) {
   equals(function (a) {}, function (a) {});
   equals({a:'1'},{a:'1'});
   equals({a:'1',b:1},{b:1,a:'1'});
-  equals({valueOf(){return 1}},{valueOf(){return 1}});
+  equals({valueOf(){return 1;}},{valueOf(){return 1;}});
   t.end();
 
   function equals (a, b) {

--- a/test.js
+++ b/test.js
@@ -61,7 +61,7 @@ test('creates unique hashes', function (t) {
 
   function test_case(value, name) {
     var hash = sum(value);
-    cases.push({ value, hash });
+    cases.push({ value: value, hash: hash });
     console.log('%s from:', hash, name || value);
   }
 });

--- a/test.js
+++ b/test.js
@@ -43,8 +43,8 @@ test('creates unique hashes', function (t) {
   test_case(void 0);
   test_case({});
   test_case({a:{},b:{}});
-  test_case({valueOf(){return 1}});
-  test_case({valueOf(){return 2}});
+  test_case({valueOf(){return 1;}});
+  test_case({valueOf(){return 2;}});
   test_case([]);
   test_case(new Date());
   test_case(new Date(2019, 5, 28));


### PR DESCRIPTION
Your existing code ignores your own jshint settings, causing it fail on missing semicolons.

This patch adds these missing semicolons and thus fixes `JSHint: Missing semicolon.(W033)` errors

Also it enables ES6 linting rules to avoid failing on `valueOf`, `const` etc.